### PR TITLE
Pluralize Curriculum Inventory endpoints

### DIFF
--- a/api/curriculuminventory/eventinstances/v1/eventinstances.md
+++ b/api/curriculuminventory/eventinstances/v1/eventinstances.md
@@ -1,9 +1,9 @@
-# EventInstance
+# EventInstances
 
 | \_ | \_ | Data Type | Notes/Description |
 | :--- | :--- | :--- | :--- |
 | Description | Provides data on a specific instance\(s\) of an event meeting certain parameters |  |  |
-| Path | /api/v1/eventinstance |  |  |
+| Path | /api/v1/eventinstances |  |  |
 | Methods | GET, POST, PUT, DELETE |  |  |
 | Parameter | ID | ID | An identifier for the event instance. |
 | Filters | Room | String | Room name |

--- a/api/curriculuminventory/events/v1/events.md
+++ b/api/curriculuminventory/events/v1/events.md
@@ -1,9 +1,9 @@
-# Event #
+# Events #
 
 | \_ | \_ | Data Types | Notes/Description |
 | :--- | :--- | :--- | :--- |
 | **Description** | Provides data on a specific curricular activity, defined by a set of expectations and goals. May have one or more instances of delivery in the curriculum ( _see_ `eventInstance`) |  |  |
-| **Path** | /api/v1/event |  |  |
+| **Path** | /api/v1/events |  |  |
 | **Methods** | GET, POST, PUT, DELETE |  |  |
 | **Parameter** | ID | URI |  |
 | **Filters** | _programID_ | String | A unique ID for the educational program to query |

--- a/api/curriculuminventory/expectations/v1/expectations.md
+++ b/api/curriculuminventory/expectations/v1/expectations.md
@@ -1,9 +1,9 @@
-# Expectation
+# Expectations
 
 | \_ | \_ | Data Types | Notes/Description |
 | :--- | :--- | :--- | :--- |
 | **Description** | Provides data on curriculum expectations meeting certain parameters. |  |  |
-| **Path** | /api/v1/expectation |  |  |
+| **Path** | /api/v1/expectations |  |  |
 | **Methods** | GET, POST, PUT DELETE |  |  |
 | **Parameter** | ID | ID |  |
 | **Filters** | Program ID | String | A unique ID for the educational program to query |

--- a/api/curriculuminventory/index.md
+++ b/api/curriculuminventory/index.md
@@ -3,9 +3,9 @@
 Health professions education programs frequently use an ecosystem of educational technologies to deliver and manage their curriculum and related resources and activities. Many institutions have curriculum management systems that help them to manage the structure and content of the curriculum. In numerous cases, separate systems will each offer assessment, evaluation, and supplemental content or activities.   
 MedBiquitous Curriculum Inventory APIs are designed to allow for effective communication with and delivery of data from a standards-compliant curriculum management or curriculum inventory system. The links below provide documentation for Curriculum Inventory operations.
 
-* [Event](/api/curriculuminventory/event/v1/event.md)
-* [Event Instance](/api/curriculuminventory/eventinstance/v1/eventinstance.md)
-* [Expectation](/api/curriculuminventory/expectation/v1/expectation.md)
+* [Events](/api/curriculuminventory/events/v1/events.md)
+* [Event Instances](/api/curriculuminventory/eventinstances/v1/eventinstances.md)
+* [Expectations](/api/curriculuminventory/expectations/v1/expectations.md)
 
 
 


### PR DESCRIPTION
When the ID is omitted these endpoints will return multiple results and
should therefor be pluralized for cognitive clarity.